### PR TITLE
Handle with ImGui API change

### DIFF
--- a/imgui_canvas.cpp
+++ b/imgui_canvas.cpp
@@ -101,8 +101,13 @@ bool ImGuiEx::Canvas::Begin(ImGuiID id, const ImVec2& size)
 
     UpdateViewTransformPosition();
 
+# if IMGUI_VERSION_NUM > 18415
+    if (ImGui::IsClippedEx(m_WidgetRect, id))
+        return false;
+# else
     if (ImGui::IsClippedEx(m_WidgetRect, id, false))
         return false;
+# endif
 
     // Save current channel, so we can assert when user
     // call canvas API with different one.


### PR DESCRIPTION
ImGui::IsClippedEx is only taking 2 arguments on ImGui greater than 1.84